### PR TITLE
feat: add keycloak and autologin support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,14 @@ GITHUB_SECRET=
 GOOGLE_ID=
 GOOGLE_SECRET=
 
+KEYCLOAK_NAME=
+KEYCLOAK_ID=
+KEYCLOAK_SECRET=
+KEYCLOAK_ISSUER=
+
+# Optional - if set to true, will try to sign in first provider
+AUTOLOGIN_FIRST_PROVIDER=
+
 # Optional - Only required if you want to use the Email Provider for NextAuth.js
 SMTP_SERVER=
 SMTP_FROM=


### PR DESCRIPTION
### Description

Allows to add Keycloak as oauth provider. Usually you set just one provider so autologin option can be set too.

### Linked Issues
https://github.com/ndom91/briefkasten/issues/31

### Additional context

Done quick, but imho we could get from payload only required properties instead of removing excessive ones. Could not find any decent white keycloak icon so lock is used, but if you agree, i will implement custom icons via variable later.
