### PR TITLE
fix(auth): add env variable for "dangerous" email account linking of Keycloak provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,9 @@ KEYCLOAK_NAME=
 KEYCLOAK_ID=
 KEYCLOAK_SECRET=
 KEYCLOAK_ISSUER=
-# Optional - https://next-auth.js.org/configuration/providers/oauth#allowdangerousemailaccountlinking-option
-KEYCLOAK_DANGER_EMAIL_ACC_LINK=
+
+# May help if getting "error=OAuthAccountNotLinked" while using Keycloak IdP, potentially dangerous(!) if TRUE, read carefully at https://next-auth.js.org/configuration/providers/oauth#allowdangerousemailaccountlinking-option
+KEYCLOAK_DANGER_EMAIL_ACC_LINK=false
 
 # Optional - if set to true, will try to sign in first provider
 AUTOLOGIN_FIRST_PROVIDER=

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,8 @@ KEYCLOAK_NAME=
 KEYCLOAK_ID=
 KEYCLOAK_SECRET=
 KEYCLOAK_ISSUER=
+# Optional - https://next-auth.js.org/configuration/providers/oauth#allowdangerousemailaccountlinking-option
+KEYCLOAK_DANGER_EMAIL_ACC_LINK=
 
 # Optional - if set to true, will try to sign in first provider
 AUTOLOGIN_FIRST_PROVIDER=

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -32,6 +32,7 @@ if (process.env.KEYCLOAK_ID) {
       name: process.env.KEYCLOAK_NAME,
       clientSecret: process.env.KEYCLOAK_SECRET,
       issuer: process.env.KEYCLOAK_ISSUER,
+      allowDangerousEmailAccountLinking: process.env.KEYCLOAK_DANGER_EMAIL_ACC_LINK,
     })
   )
 }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

It should solve the "error=OAuthAccountNotLinked" issue when using Keycloak provider

### Linked Issues

https://github.com/ndom91/briefkasten/issues/31
