### PR TITLE
fix: update the version of pnpm and nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim as dependencies
+FROM node:20-bullseye-slim as dependencies
 
 LABEL org.opencontainers.image.title="Briefkasten" \
   org.opencontainers.image.description="Modern Bookmarking Application" \
@@ -29,7 +29,7 @@ COPY package.json pnpm-lock.yaml prisma ./
 RUN pnpm install --frozen-lockfile
 
 # ---- Build ----
-FROM node:16-bullseye-slim as build
+FROM node:20-bullseye-slim as build
 WORKDIR /app
 
 # Install pnpm
@@ -53,7 +53,7 @@ RUN pnpm dlx prisma generate
 RUN pnpm build
 
 # ---- Release ----
-FROM node:16-bullseye-slim as release
+FROM node:20-bullseye-slim as release
 WORKDIR /app
 
 # openssl for prisma

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "db:push": "npx prisma db push",
     "db:studio": "npx prisma studio"
   },
-  "packageManager": "pnpm@7.5.1",
+  "packageManager": "pnpm@9.1.3",
   "dependencies": {
     "@headlessui/react": "^1.7.7",
     "@next-auth/prisma-adapter": "^1.0.5",


### PR DESCRIPTION
### Description
When I cloned the codes and tried to self-host Briefkasten with Docker, I got these two error logs:
![image](https://github.com/ndom91/briefkasten/assets/141131070/55592d2f-f88f-4db1-8404-08c640f93bf6)
![image](https://github.com/ndom91/briefkasten/assets/141131070/b470c78d-45fd-4307-861b-8adce96067e7)

When I tried to use pnpm@7.5.1 and nodejs v16, It didn't work well. So I updated the version of pnpm@9.1.3 and nodejs v20, and now  it works perfectly! 

