### PR TITLE
chore: bump Node base image to v18 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-bullseye-slim as dependencies
+FROM node:18-bookworm-slim as dependencies
 
 LABEL org.opencontainers.image.title="Briefkasten" \
   org.opencontainers.image.description="Modern Bookmarking Application" \
@@ -29,7 +29,7 @@ COPY package.json pnpm-lock.yaml prisma ./
 RUN pnpm install --frozen-lockfile
 
 # ---- Build ----
-FROM node:16-bullseye-slim as build
+FROM node:18-bookworm-slim as build
 WORKDIR /app
 
 # Install pnpm
@@ -53,7 +53,7 @@ RUN pnpm dlx prisma generate
 RUN pnpm build
 
 # ---- Release ----
-FROM node:16-bullseye-slim as release
+FROM node:18-bookworm-slim as release
 WORKDIR /app
 
 # openssl for prisma


### PR DESCRIPTION
### Description
This PR bumps the Node base image used in the Dockerfile from v16 to v18. This fixes local docker builds (see #68).
The underlying Debian base is also bumped from Bullseye to Bookworm.

### Linked Issues
Fixes #68